### PR TITLE
Add alphabetical movie list

### DIFF
--- a/content/movies-a-z/_index.md
+++ b/content/movies-a-z/_index.md
@@ -1,0 +1,4 @@
+---
+title: Movies A-Z
+layout: list-alpha
+---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -61,6 +61,9 @@
     {{ with $.Site.GetPage "/keywords" }}
       <li><a href="{{ .RelPermalink }}">By Keyword</a></li>
     {{ end }}
+    {{ with $.Site.GetPage "/movies-a-z" }}
+      <li><a href="{{ .RelPermalink }}">Movies A-Z</a></li>
+    {{ end }}
   </ul>
 </div>
 

--- a/layouts/movies/list-alpha.html
+++ b/layouts/movies/list-alpha.html
@@ -1,0 +1,30 @@
+{{ define "main" }}
+<h1>{{.Title}}</h1>
+
+<p>{{ partial "breadcrumb.html" . }}</p>
+
+{{ with .Content }}
+<div>{{ . }}</div>
+{{ end }}
+
+<table>
+  <tr>
+    <td>Title</td>
+    <td>Release Year</td>
+    <td>Score</td>
+  </tr>
+
+  {{ range .Data.Pages.ByParam "title_alpha_sortable" }}
+    <tr>
+      <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
+      <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
+
+      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
+      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
+      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
+      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
+    </tr>
+
+  {{ end }}
+</table>
+{{ end }}


### PR DESCRIPTION
## Summary
- create `list-alpha` layout to sort movies alphabetically
- expose alphabetical list at `/movies-a-z/`
- link new list from the home page
- fix broken link path

## Testing
- `npm test` *(fails: Missing script)*
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_6867de5995908323b4bc7c1d0432b37e