### PR TITLE
Add alternate movie list sorted by score

### DIFF
--- a/content/movies-by-score/_index.md
+++ b/content/movies-by-score/_index.md
@@ -1,0 +1,4 @@
+---
+title: Movies by Score
+layout: list-score
+---

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -19,14 +19,11 @@
   </tr>
 
   {{ range .Data.Pages.ByParam "release_date" }}
+    {{ $info := index (partial "weighted-scores.html" (slice .)) 0 }}
     <tr>
       <td><a href="{{ .RelPermalink }}">{{ .Title }}</a></td>
       <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
-
-      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
-      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
-      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
-      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
+      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 $info.score }}</td>
     </tr>
 
   {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -64,6 +64,9 @@
     {{ with $.Site.GetPage "/movies-a-z" }}
       <li><a href="{{ .RelPermalink }}">Movies A-Z</a></li>
     {{ end }}
+    {{ with $.Site.GetPage "/movies-by-score" }}
+      <li><a href="{{ .RelPermalink }}">Movies by Score</a></li>
+    {{ end }}
   </ul>
 </div>
 

--- a/layouts/movies/list-alpha.html
+++ b/layouts/movies/list-alpha.html
@@ -15,14 +15,11 @@
   </tr>
 
   {{ range .Data.Pages.ByParam "title_alpha_sortable" }}
+    {{ $info := index (partial "weighted-scores.html" (slice .)) 0 }}
     <tr>
       <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
       <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
-
-      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
-      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
-      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
-      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
+      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 $info.score }}</td>
     </tr>
 
   {{ end }}

--- a/layouts/movies/list-score.html
+++ b/layouts/movies/list-score.html
@@ -1,0 +1,26 @@
+{{ define "main" }}
+<h1>{{.Title}}</h1>
+
+<p>{{ partial "breadcrumb.html" . }}</p>
+
+{{ with .Content }}
+<div>{{ . }}</div>
+{{ end }}
+
+<table>
+  <tr>
+    <td>Title</td>
+    <td>Release Year</td>
+    <td>Score</td>
+  </tr>
+  {{ $pages := partial "weighted-scores.html" .Data.Pages }}
+  {{ range sort $pages "score" "desc" }}
+    {{ $p := .page }}
+    <tr>
+      <td><a class="random-target" href="{{ $p.RelPermalink }}">{{ $p.Title }}</a></td>
+      <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index $p.Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index $p.Params.release_years 0 }}</a></td>
+      <td title="RT: {{ $p.Params.rotten_tomatoes.score }} ({{ $p.Params.rotten_tomatoes.review_count}}), MC: {{ $p.Params.metacritic.score }} ({{ $p.Params.metacritic.review_count}})">{{ lang.NumFmt 2 .score }}</td>
+    </tr>
+  {{ end }}
+</table>
+{{ end }}

--- a/layouts/movies/list.html
+++ b/layouts/movies/list.html
@@ -15,14 +15,11 @@
   </tr>
 
   {{ range .Data.Pages.ByParam "release_date" }}
+    {{ $info := index (partial "weighted-scores.html" (slice .)) 0 }}
     <tr>
       <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
       <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
-
-      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
-      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
-      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
-      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
+      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 $info.score }}</td>
     </tr>
 
   {{ end }}

--- a/layouts/movies/single.html
+++ b/layouts/movies/single.html
@@ -23,10 +23,8 @@
   {{ $rt := . }}
   {{ with $.Params.metacritic }}
     {{ $mc := . }}
-    {{ $mcWeights := mul $mc.score $mc.review_count }}
-    {{ $rtWeights := mul $rt.score $rt.review_count }}
-    {{ $totalReviews := add $mc.review_count $rt.review_count }}
-    <p>✨ Weighted Score: <strong>{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</strong></p>
+    {{ $info := index (partial "weighted-scores.html" (slice $)) 0 }}
+    <p>✨ Weighted Score: <strong>{{ lang.NumFmt 2 $info.score }}</strong></p>
   {{ end }}
 {{ end }}
 {{ with .Params.rotten_tomatoes }}

--- a/layouts/partials/weighted-scores.html
+++ b/layouts/partials/weighted-scores.html
@@ -1,0 +1,9 @@
+{{- $result := slice -}}
+{{- range . -}}
+  {{- $mcw := mul .Params.metacritic.score .Params.metacritic.review_count -}}
+  {{- $rtw := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count -}}
+  {{- $total := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count -}}
+  {{- $score := div (add $mcw $rtw) (float $total) -}}
+  {{- $result = $result | append (dict "page" . "score" $score "mcw" $mcw "rtw" $rtw "total" $total) -}}
+{{- end -}}
+{{- return $result -}}


### PR DESCRIPTION
## Summary
- list movies by weighted score descending
- add page at `/movies-by-score`
- link the page from index
- extract helper for calculating weighted scores

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686ac7a4d0788323a6dc0a7d29a65e35