### PR TITLE
Add weighted score helper and movies by score list

### DIFF
--- a/content/movies-by-score/_index.md
+++ b/content/movies-by-score/_index.md
@@ -1,0 +1,3 @@
+---
+title: Movies by Score
+---

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -18,18 +18,16 @@
     <td>Score</td>
   </tr>
 
-  {{ range .Data.Pages.ByParam "release_date" }}
-    <tr>
-      <td><a href="{{ .RelPermalink }}">{{ .Title }}</a></td>
-      <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
+    {{ range .Data.Pages.ByParam "release_date" }}
+      <tr>
+        <td><a href="{{ .RelPermalink }}">{{ .Title }}</a></td>
+        <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
 
-      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
-      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
-      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
-      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
-    </tr>
+        {{ $score := partial "weighted-score.html" . }}
+        <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 $score }}</td>
+      </tr>
 
-  {{ end }}
+    {{ end }}
 </table>
 
 {{ else }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -64,6 +64,9 @@
     {{ with $.Site.GetPage "/movies-a-z" }}
       <li><a href="{{ .RelPermalink }}">Movies A-Z</a></li>
     {{ end }}
+    {{ with $.Site.GetPage "/movies-by-score" }}
+      <li><a href="{{ .RelPermalink }}">Movies by Score</a></li>
+    {{ end }}
   </ul>
 </div>
 

--- a/layouts/movies-a-z/list-alpha.html
+++ b/layouts/movies-a-z/list-alpha.html
@@ -14,17 +14,15 @@
     <td>Score</td>
   </tr>
 
-  {{ range (where $.Site.RegularPages "Section" "movies" ).ByParam "title_alpha_sortable" }}
-    <tr>
-      <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
-      <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
+    {{ range (where $.Site.RegularPages "Section" "movies" ).ByParam "title_alpha_sortable" }}
+      <tr>
+        <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
+        <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
 
-      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
-      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
-      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
-      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
-    </tr>
+        {{ $score := partial "weighted-score.html" . }}
+        <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 $score }}</td>
+      </tr>
 
-  {{ end }}
+    {{ end }}
 </table>
 {{ end }}

--- a/layouts/movies-by-score/list.html
+++ b/layouts/movies-by-score/list.html
@@ -1,0 +1,31 @@
+{{ define "main" }}
+<h1>{{ .Title }}</h1>
+
+<p>{{ partial "breadcrumb.html" . }}</p>
+
+{{ with .Content }}
+<div>{{ . }}</div>
+{{ end }}
+
+<table>
+  <tr>
+    <td>Title</td>
+    <td>Release Year</td>
+    <td>Score</td>
+  </tr>
+  {{ $sortable := slice }}
+  {{ range where $.Site.RegularPages "Section" "movies" }}
+    {{ $score := partial "weighted-score.html" . }}
+    {{ $sortable = $sortable | append (dict "page" . "score" $score) }}
+  {{ end }}
+  {{ range sort $sortable "score" "desc" }}
+    {{ $p := .page }}
+    {{ $score := .score }}
+    <tr>
+      <td><a class="random-target" href="{{ $p.RelPermalink }}">{{ $p.Title }}</a></td>
+      <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index $p.Params.release_years 0)) }}{{ .RelPermalink}}{{ end }}">{{ index $p.Params.release_years 0 }}</a></td>
+      <td title="RT: {{ $p.Params.rotten_tomatoes.score }} ({{ $p.Params.rotten_tomatoes.review_count}}), MC: {{ $p.Params.metacritic.score }} ({{ $p.Params.metacritic.review_count}})">{{ lang.NumFmt 2 $score }}</td>
+    </tr>
+  {{ end }}
+</table>
+{{ end }}

--- a/layouts/movies/list-alpha.html
+++ b/layouts/movies/list-alpha.html
@@ -14,17 +14,15 @@
     <td>Score</td>
   </tr>
 
-  {{ range (where $.Site.RegularPages "Section" "movies" ).ByParam "title_alpha_sortable" }}
-    <tr>
-      <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
-      <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
+    {{ range (where $.Site.RegularPages "Section" "movies" ).ByParam "title_alpha_sortable" }}
+      <tr>
+        <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
+        <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
 
-      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
-      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
-      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
-      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
-    </tr>
+        {{ $score := partial "weighted-score.html" . }}
+        <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 $score }}</td>
+      </tr>
 
-  {{ end }}
+    {{ end }}
 </table>
 {{ end }}

--- a/layouts/movies/list.html
+++ b/layouts/movies/list.html
@@ -14,17 +14,15 @@
     <td>Score</td>
   </tr>
 
-  {{ range .Data.Pages.ByParam "release_date" }}
-    <tr>
-      <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
-      <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
+    {{ range .Data.Pages.ByParam "release_date" }}
+      <tr>
+        <td><a class="random-target" href="{{ .RelPermalink }}">{{ .Title }}</a></td>
+        <td><a href="{{ with $.GetPage (printf "/release_years/%s" (index .Params.release_years 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.release_years 0 }}</a></td>
 
-      {{ $mcWeights := mul .Params.metacritic.score .Params.metacritic.review_count }}
-      {{ $rtWeights := mul .Params.rotten_tomatoes.score .Params.rotten_tomatoes.review_count }}
-      {{ $totalReviews := add .Params.metacritic.review_count .Params.rotten_tomatoes.review_count }}
-      <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</td>
-    </tr>
+        {{ $score := partial "weighted-score.html" . }}
+        <td title="RT: {{ .Params.rotten_tomatoes.score }} ({{ .Params.rotten_tomatoes.review_count}}), MC: {{ .Params.metacritic.score }} ({{ .Params.metacritic.review_count}})">{{ lang.NumFmt 2 $score }}</td>
+      </tr>
 
-  {{ end }}
+    {{ end }}
 </table>
 {{ end }}

--- a/layouts/movies/single.html
+++ b/layouts/movies/single.html
@@ -20,13 +20,9 @@
 <p>⏲️ Runtime: <strong>{{ .Params.runtime_minutes}} minutes</strong></p>
 
 {{ with .Params.rotten_tomatoes }}
-  {{ $rt := . }}
   {{ with $.Params.metacritic }}
-    {{ $mc := . }}
-    {{ $mcWeights := mul $mc.score $mc.review_count }}
-    {{ $rtWeights := mul $rt.score $rt.review_count }}
-    {{ $totalReviews := add $mc.review_count $rt.review_count }}
-    <p>✨ Weighted Score: <strong>{{ lang.NumFmt 2 (div (add $mcWeights $rtWeights) (float $totalReviews)) }}</strong></p>
+    {{ $weighted := partial "weighted-score.html" $ }}
+    <p>✨ Weighted Score: <strong>{{ lang.NumFmt 2 $weighted }}</strong></p>
   {{ end }}
 {{ end }}
 {{ with .Params.rotten_tomatoes }}

--- a/layouts/partials/weighted-score.html
+++ b/layouts/partials/weighted-score.html
@@ -1,0 +1,6 @@
+{{- $mc := .Params.metacritic -}}
+{{- $rt := .Params.rotten_tomatoes -}}
+{{- $mcWeights := mul $mc.score $mc.review_count -}}
+{{- $rtWeights := mul $rt.score $rt.review_count -}}
+{{- $totalReviews := add $mc.review_count $rt.review_count -}}
+{{- return (div (add $mcWeights $rtWeights) (float $totalReviews)) -}}


### PR DESCRIPTION
## Summary
- calculate movie weighted score in a new `weighted-score` partial
- replace inline weighted score logic in templates
- add list of movies sorted by weighted score
- link new list from home page

## Testing
- `npm test` *(fails: Missing script)*
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_686af99148c88323b7da454ba11ed76f