### PR TITLE
Add Open Graph metadata for sharing

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,7 @@
   	<title>{{ block "title" . }}{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}{{ end }}</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 16 16'><text x='0' y='14'>📼</text></svg>" />
     <meta id="description" name="description" content="{{ block "description" . }}{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.site_description }}{{ end }}{{ end }}"/>
+    {{ partial "share-meta.html" . }}
 
     {{ if eq (getenv "HUGO_ENV") "production" }}
       <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">

--- a/layouts/partials/share-meta.html
+++ b/layouts/partials/share-meta.html
@@ -1,0 +1,20 @@
+{{- /* Open Graph and Twitter meta tags for sharing */ -}}
+{{- $title := .Title | default .Site.Title -}}
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="{{ .Permalink }}">
+{{- $desc := .Params.tagline | default .Description | default .Params.overview -}}
+{{- if $desc }}
+<meta property="og:description" content="{{ $desc }}">
+{{- end }}
+{{- with .Params.poster_path }}
+  {{- $clean := strings.TrimPrefix "/" . -}}
+  {{- $imageURL := printf "%sapi/images/%s" $.Site.BaseURL $clean -}}
+  <meta property="og:image" content="{{ $imageURL }}">
+  <meta name="twitter:image" content="{{ $imageURL }}">
+{{- end }}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+{{- if $desc }}
+<meta name="twitter:description" content="{{ $desc }}">
+{{- end }}


### PR DESCRIPTION
## Summary
- add a share-meta partial with Open Graph and Twitter tags
- use the new partial in `baseof.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867de943b208323bbf7fe3f7510647f